### PR TITLE
SSL can be verified. This PR fixes #19.

### DIFF
--- a/clients/client.php
+++ b/clients/client.php
@@ -20,7 +20,8 @@ class Client
         if (isset($this->nuid) &&
             isset($this->pin) &&
             strlen($this->pin) === 4 &&
-            strlen($this->nuid) == 8)
+            strlen($this->nuid) == 8 &&
+            isset($_SERVER['HTTPS']))
         {
             $response = true;
         }

--- a/ssl.php
+++ b/ssl.php
@@ -1,0 +1,9 @@
+<?php
+
+header('Content-Type: application/json');
+
+$response = isset($_SERVER['HTTPS']);
+
+echo json_encode(array('status' => $response));
+
+?>


### PR DESCRIPTION
This PR creates two things. 

1. It enables users to check whether their connection uses SSL. This can be verified by calling `ssl.php`. The response will be a status code with either true or false.

2. It refuses all calls that do not use SSL. To avoid this, the banks should use `ssl.php` first.